### PR TITLE
fix: use correct urls for blog post tags

### DIFF
--- a/public/rss/feed.xsl
+++ b/public/rss/feed.xsl
@@ -65,7 +65,7 @@
 
                   <p>Tags:
                     <xsl:for-each select="category">
-                      <a href="https://sapphic.moe/articles/tag/{.}" target="_blank">
+                      <a href="https://sapphic.moe/articles/tags/{.}" target="_blank">
                         <span>
                           <xsl:value-of select="." />
                         </span>

--- a/src/components/blog/Tag.astro
+++ b/src/components/blog/Tag.astro
@@ -7,5 +7,5 @@ const { tag } = Astro.props;
 ---
 
 <span class="mr-1">
-  <a href={`/articles/tag/${tag}`} title={`Article tagged with ${tag}`}>#{tag}</a>
+  <a href={`/articles/tags/${tag}`} title={`Article tagged with ${tag}`}>#{tag}</a>
 </span>


### PR DESCRIPTION
Hi there! Website source uses "tags" for tag path (`src/pages/articles/tags/[tag]/[...page].astro`), but Tag component links it as "tag" (`/articles/tag/${tag}`), meaning all tag links from this Tag component are invalid (e.g. going to https://sapphic.moe/article/oneshot-on-linux/ and clicking [#linux](https://sapphic.moe/articles/tag/linux) will send you to 404 page). The same issue applies to RSS thingy (`public/rss/feed.xsl`), I also fixed it. 404's shouldn't happen anymore.

As a form of test, here's output of recursive wget before (running from `master`):
```
[/tmp] $ wget -rl0 http://localhost:1337 2>&1 | grep -B2 404
--2025-03-09 13:15:28--  http://localhost:1337/articles/tag/oneshot
Reusing existing connection to [localhost]:1337.
HTTP request sent, awaiting response... 404 Not Found
2025-03-09 13:15:28 ERROR 404: Not Found.
--
--2025-03-09 13:15:28--  http://localhost:1337/articles/tag/linux
Connecting to localhost (localhost)|::1|:1337... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-03-09 13:15:28 ERROR 404: Not Found.
--
--2025-03-09 13:15:28--  http://localhost:1337/articles/tag/cloudflare
Reusing existing connection to [localhost]:1337.
HTTP request sent, awaiting response... 404 Not Found
2025-03-09 13:15:28 ERROR 404: Not Found.
--
--2025-03-09 13:15:28--  http://localhost:1337/articles/tag/owncloud
Connecting to localhost (localhost)|::1|:1337... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-03-09 13:15:28 ERROR 404: Not Found.
```
And after (running from `tags-patch`):
```
[/tmp] $ wget -rl0 http://localhost:1337 2>&1 | grep -B2 404
[ble: exit 1]
```